### PR TITLE
feat(context): make scrape menu toggle-able #240

### DIFF
--- a/src/components/panel/settings/common/settings-accordion.tsx
+++ b/src/components/panel/settings/common/settings-accordion.tsx
@@ -15,6 +15,7 @@ import type { Dispatch, SetStateAction } from 'react';
 export const SettingsAccordion = <T extends { id: string }>({
   title,
   list,
+  header,
   detail,
   summary,
   addNew,
@@ -24,6 +25,7 @@ export const SettingsAccordion = <T extends { id: string }>({
 }: {
   title: InterfaceHeader;
   list: T[];
+  header?: JSX.Element;
   summary: (item: T) => JSX.Element;
   detail: (item: T) => JSX.Element;
   addNew?: (id: string) => void;
@@ -53,6 +55,7 @@ export const SettingsAccordion = <T extends { id: string }>({
         title={i18n(`title__${title}`)}
         titleTypographyProps={{ variant: 'h6', color: 'text.primary', sx: { textTransform: 'capitalize' } }}
         sx={{ p: '1rem 1rem 0' }}
+        subheader={header}
       />
       <CardContent>
         <SortableList

--- a/src/i18n/en/panel/settings/interface/settings-context-menus.json
+++ b/src/i18n/en/panel/settings/interface/settings-context-menus.json
@@ -1,5 +1,11 @@
 {
   "panel__settings__context_menus__default_folder": {
     "message": "Default folder"
+  },
+  "panel__settings__context_menus__scrape_menu_title": {
+    "message": "Scape context menu"
+  },
+  "panel__settings__context_menus__scrape_menu_subheader": {
+    "message": "Enable/disable the scrape context menu."
   }
 }

--- a/src/i18n/zh/panel/settings/interface/settings-context-menus.json
+++ b/src/i18n/zh/panel/settings/interface/settings-context-menus.json
@@ -1,5 +1,11 @@
 {
   "panel__settings__context_menus__default_folder": {
     "message": "默认文件夹"
+  },
+  "panel__settings__context_menus__scrape_menu_title": {
+    "message": "抓取上下文菜单"
+  },
+  "panel__settings__context_menus__scrape_menu_subheader": {
+    "message": "启用/禁用抓取上下文菜单。"
   }
 }

--- a/src/models/menu.model.ts
+++ b/src/models/menu.model.ts
@@ -119,7 +119,7 @@ export const defaultContextMenu: ContextMenu = {
   destination: { custom: false },
 };
 
-export const scrapeContextMenu: ChromeContextMenu = {
+export const scrapeContextMenu: ChromeContextMenu & { id: string } = {
   id: uuid(),
   title: 'Scrape Page',
   contexts: [ContextType.page],

--- a/src/models/message.model.ts
+++ b/src/models/message.model.ts
@@ -24,6 +24,7 @@ export enum ChromeMessageType {
   updateMenu = 'updateMenu',
   removeMenu = 'removeMenu',
   resetMenu = 'resetMenu',
+  toggleScrapeMenu = 'toggleScrapeMenu',
   notificationBanner = 'notificationBanner',
   notificationSnack = 'notificationSnack',
   polling = 'polling',
@@ -68,6 +69,11 @@ export type OpenPanelPayload = {
   intercept?: TaskDialogIntercept;
 };
 
+export type ResetMenuPayload = {
+  menus: ContextMenu[];
+  scrape?: boolean;
+};
+
 /**
  * Type union of possible message payloads
  */
@@ -75,7 +81,7 @@ export type ChromeMessagePayload =
   | boolean
   | string
   | ContextMenu
-  | ContextMenu[]
+  | ResetMenuPayload
   | ChromeNotification
   | SynologyQueryPayload
   | DownloadQueryPayload

--- a/src/models/settings.model.ts
+++ b/src/models/settings.model.ts
@@ -416,6 +416,14 @@ export const defaultSyncSettings: SyncSettings = {
   mode: SyncSettingMode.sync,
 };
 
+export interface ScrapeSettings {
+  menu: boolean;
+}
+
+export const defaultScrapeSettings: ScrapeSettings = {
+  menu: true,
+};
+
 export interface TaskSettings {
   clearOnExist: boolean;
 }
@@ -436,4 +444,5 @@ export const defaultSettings: SettingsSlice = {
   downloads: defaultDownloads,
   advanced: defaultAdvancedSettings,
   sync: defaultSyncSettings,
+  scrape: defaultScrapeSettings,
 };

--- a/src/models/store.model.ts
+++ b/src/models/store.model.ts
@@ -15,6 +15,7 @@ import type {
   Log,
   NotificationSettings,
   PollingSettings,
+  ScrapeSettings,
   SyncSettings,
   TaskSettings,
 } from './settings.model';
@@ -89,6 +90,7 @@ export interface SettingsSlice {
   downloads: DownloadSettings;
   advanced: AdvancedSettings;
   sync: SyncSettings;
+  scrape: ScrapeSettings;
 }
 
 export interface RootSlice {

--- a/src/pages/background/modules/context-menu.handler.ts
+++ b/src/pages/background/modules/context-menu.handler.ts
@@ -1,42 +1,50 @@
-import type { ContextMenu } from '@src/models';
+import type { ContextMenu, ResetMenuPayload } from '@src/models';
 import { ChromeMessageType } from '@src/models';
 import { LoggerService } from '@src/services';
-import { buildContextMenu, onMessage, removeContextMenu, saveContextMenu } from '@src/utils';
-
-import type { Observable } from 'rxjs';
+import { buildContextMenu, onMessage, removeContextMenu, saveContextMenu, toggleScrapeContextMenu } from '@src/utils';
 
 /** Listen to context menu events to create/updates menus */
 export const onContextMenuEvents = () => {
   LoggerService.debug('Subscribing to context menu events.');
 
   // On message from chrome handle payload
-  onMessage([ChromeMessageType.addMenu, ChromeMessageType.updateMenu, ChromeMessageType.removeMenu, ChromeMessageType.resetMenu]).subscribe(
-    ({ message, sendResponse }) => {
-      if (message) {
-        const { type, payload } = message;
-        const handle = <T>(obs$: Observable<T>) =>
-          obs$.subscribe({
-            next: () => sendResponse({ success: true, payload }),
-            error: error => sendResponse({ success: false, error }),
-          });
-
-        switch (type) {
-          case ChromeMessageType.addMenu:
-            handle(saveContextMenu(payload as ContextMenu));
-            break;
-          case ChromeMessageType.updateMenu:
-            handle(saveContextMenu(payload as ContextMenu, true));
-            break;
-          case ChromeMessageType.removeMenu:
-            handle(removeContextMenu(payload as string));
-            break;
-          case ChromeMessageType.resetMenu:
-            handle(buildContextMenu(payload as ContextMenu[]));
-            break;
-          default:
-            LoggerService.error(`Message type '${type}' not supported`);
+  onMessage([
+    ChromeMessageType.addMenu,
+    ChromeMessageType.updateMenu,
+    ChromeMessageType.removeMenu,
+    ChromeMessageType.toggleScrapeMenu,
+    ChromeMessageType.resetMenu,
+  ]).subscribe(async ({ message, sendResponse }) => {
+    if (message) {
+      const { type, payload } = message;
+      const handle = async <T>(promise: Promise<T>) => {
+        try {
+          await promise;
+          sendResponse({ success: true, payload });
+        } catch (error) {
+          sendResponse({ success: false, error: error as Error });
         }
+      };
+
+      switch (type) {
+        case ChromeMessageType.addMenu:
+          await handle(saveContextMenu(payload as ContextMenu));
+          break;
+        case ChromeMessageType.updateMenu:
+          await handle(saveContextMenu(payload as ContextMenu, true));
+          break;
+        case ChromeMessageType.removeMenu:
+          await handle(removeContextMenu(payload as string));
+          break;
+        case ChromeMessageType.toggleScrapeMenu:
+          await handle(toggleScrapeContextMenu(payload as boolean));
+          break;
+        case ChromeMessageType.resetMenu:
+          await handle(buildContextMenu(payload as ResetMenuPayload));
+          break;
+        default:
+          LoggerService.error(`Message type '${type}' not supported`);
       }
-    },
-  );
+    }
+  });
 };

--- a/src/pages/background/modules/settings-handler.ts
+++ b/src/pages/background/modules/settings-handler.ts
@@ -1,11 +1,11 @@
-import { catchError, finalize, from, lastValueFrom, of, switchMap } from 'rxjs';
+import { catchError, finalize, from, of, switchMap } from 'rxjs';
 
 import type { SettingsSlice } from '@src/models';
 import { defaultSettings, SyncSettingMode } from '@src/models';
 import { LoggerService } from '@src/services';
 import { setNavbar, setSettings } from '@src/store/actions';
 import { settingsSlice } from '@src/store/slices/settings.slice';
-import { localGet, syncGet, buildContextMenu, setBadgeBackgroundColor } from '@src/utils';
+import { buildContextMenu, localGet, setBadgeBackgroundColor, syncGet } from '@src/utils';
 
 import type { Store } from 'redux';
 
@@ -25,7 +25,7 @@ const dispatchRestoreSettings = async (store: Store, settings: SettingsSlice) =>
   if (settings?.tabs?.length) await store.dispatch(setNavbar(settings?.tabs[0]));
 
   // restore context menu
-  await lastValueFrom(buildContextMenu(settings?.menus || defaultSettings.menus));
+  await buildContextMenu({ menus: settings?.menus || defaultSettings.menus, scrape: settings?.scrape?.menu });
   return settings;
 };
 

--- a/src/store/actions/settings.action.ts
+++ b/src/store/actions/settings.action.ts
@@ -28,6 +28,7 @@ const {
   syncAdvancedLogging,
   setSyncSettings,
   syncTasksSettings,
+  syncScrapeSettings,
 } = settingsSlice.actions;
 
 // Export as named constants
@@ -58,4 +59,5 @@ export {
   syncAdvancedLogging,
   setSyncSettings,
   syncTasksSettings,
+  syncScrapeSettings,
 };

--- a/src/store/selectors/settings.selector.ts
+++ b/src/store/selectors/settings.selector.ts
@@ -21,6 +21,7 @@ import {
   defaultDownloads,
   defaultGlobal,
   defaultLoggingLevels,
+  defaultScrapeSettings,
   defaultTaskSettings,
   TaskStatus,
   ThemeMode,
@@ -107,6 +108,8 @@ export const getNotificationsBannerLevel = createSelector(getNotificationsBanner
 export const getNotificationsBannerFailedEnabled = createSelector(getNotificationsBanner, (banner: NotificationsBanner) => banner?.scope.failed);
 
 export const getNotificationsBannerFinishedEnabled = createSelector(getNotificationsBanner, (banner: NotificationsBanner) => banner?.scope.finished);
+
+export const getScrapeSettings = createSelector(getSettings, (setting: SettingsSlice) => setting?.scrape ?? defaultScrapeSettings);
 
 export const getGlobal = createSelector(getSettings, (setting: SettingsSlice) => setting?.global);
 

--- a/src/store/slices/settings.slice.ts
+++ b/src/store/slices/settings.slice.ts
@@ -12,6 +12,7 @@ import type {
   NotificationSettings,
   PollingSettings,
   QuickMenu,
+  ScrapeSettings,
   SettingsSlice,
   SyncSettings,
   TaskSettings,
@@ -60,6 +61,7 @@ interface SettingsReducers<S = SettingsSlice> extends SliceCaseReducers<S> {
   syncAdvancedLogging: CaseReducer<S, PayloadAction<AdvancedLogging>>;
   setSyncSettings: CaseReducer<S, PayloadAction<Partial<SyncSettings>>>;
   syncTasksSettings: CaseReducer<S, PayloadAction<TaskSettings>>;
+  syncScrapeSettings: CaseReducer<S, PayloadAction<Partial<ScrapeSettings>>>;
 }
 
 export const settingsSlice = createSlice<SettingsSlice, SettingsReducers, 'settings'>({
@@ -120,5 +122,6 @@ export const settingsSlice = createSlice<SettingsSlice, SettingsReducers, 'setti
     syncAdvancedLogging: syncAdvancedLoggingReducer,
     setSyncSettings: setSyncSettingsReducer,
     syncTasksSettings: (oldSettings, { payload }) => syncNestedReducer<TaskSettings>(oldSettings, payload, 'tasks'),
+    syncScrapeSettings: (oldSettings, { payload }) => syncNestedReducer<ScrapeSettings>(oldSettings, payload, 'scrape'),
   },
 });


### PR DESCRIPTION
### Updates to `SettingsAccordion` Component:
- Added an optional `header` prop to the `SettingsAccordion` component, allowing customization of the header section with JSX elements. 

### Scrape Context Menu Feature:
- Introduced `ScrapeSettings` in the Redux store to manage the visibility of the scrape context menu. 
- Added actions and reducers for syncing scrape settings. 
- Updated selectors to retrieve scrape settings from the store. 

### Context Menu Utilities:
- Implemented a utility function, `toggleScrapeContextMenu`, to dynamically add or remove the scrape context menu based on user settings. 
- Enhanced the message handling logic to support the new `toggleScrapeMenu` Chrome message type and payload structure. 

### Internationalization:
- Added English and Chinese translations for the scrape context menu feature, including its title and subheader. 

### Integration with Settings:
- Updated settings restoration logic to include scrape menu settings during initialization. 