### PR TITLE
feat(quick-menu): add setting to toggle on/off quick menus. #243

### DIFF
--- a/src/components/panel/settings/interface/settings-quick-menus.tsx
+++ b/src/components/panel/settings/interface/settings-quick-menus.tsx
@@ -1,14 +1,16 @@
-import { Typography } from '@mui/material';
+import { CardHeader, Typography } from '@mui/material';
 
 import React, { useState } from 'react';
 
+import { useForm } from 'react-hook-form';
 import { useDispatch, useSelector } from 'react-redux';
 
-import type { QuickMenu } from '@src/models';
-import { defaultQuickMenu, InterfaceHeader } from '@src/models';
+import { FormSwitch } from '@src/components';
+import type { ContentSettings, QuickMenu } from '@src/models';
+import { defaultContentSettings, defaultQuickMenu, InterfaceHeader } from '@src/models';
 import type { StoreState } from '@src/store';
-import { resetQuickMenus, saveQuickMenu, setQuickMenus } from '@src/store/actions';
-import { getQuick } from '@src/store/selectors';
+import { resetQuickMenus, saveQuickMenu, setQuickMenus, syncContentSettings } from '@src/store/actions';
+import { getContentSettings, getQuick } from '@src/store/selectors';
 import { useI18n } from '@src/utils';
 
 import { SettingsAccordion } from '../common';
@@ -31,11 +33,41 @@ export const SettingsQuickMenus = () => {
 
   const onChange = (_menus: QuickMenu[]) => dispatch(setQuickMenus(_menus));
 
+  const contentSettings = useSelector<StoreState, ContentSettings>(getContentSettings);
+
+  const { control } = useForm<ContentSettings>({
+    mode: 'onChange',
+    defaultValues: {
+      ...contentSettings,
+      intercept: contentSettings.intercept ?? defaultContentSettings.intercept,
+    },
+  });
+
+  async function toggleIntercept(enabled = true) {
+    dispatch(syncContentSettings({ intercept: enabled }));
+  }
+
   return (
     <SettingsAccordion
       state={state}
       title={InterfaceHeader.quickMenu}
       list={menus}
+      header={
+        <CardHeader
+          title={i18n('enabled_title')}
+          subheader={i18n('enabled_subheader')}
+          titleTypographyProps={{ variant: 'subtitle2' }}
+          subheaderTypographyProps={{ variant: 'subtitle2' }}
+          action={
+            <FormSwitch
+              controllerProps={{ name: 'intercept', control }}
+              formControlLabelProps={{ label: '' }}
+              switchProps={{ onChange: (_, checked) => toggleIntercept(checked) }}
+            />
+          }
+          sx={{ p: '0.5rem 0' }}
+        />
+      }
       summary={m => (
         <>
           <Typography sx={{ width: '40%', flexShrink: 0 }}>{m.title}</Typography>

--- a/src/i18n/en/panel/settings/interface/settings-quick-menus.json
+++ b/src/i18n/en/panel/settings/interface/settings-quick-menus.json
@@ -1,5 +1,11 @@
 {
   "panel__settings__quick_menus__default_folder": {
     "message": "Default folder"
+  },
+  "panel__settings__quick_menus__enabled_title": {
+    "message": "Quick menu interception"
+  },
+  "panel__settings__quick_menus__enabled_subheader": {
+    "message": "Enable/disable the quick menu interception feature."
   }
 }

--- a/src/i18n/zh/panel/settings/interface/settings-quick-menus.json
+++ b/src/i18n/zh/panel/settings/interface/settings-quick-menus.json
@@ -1,5 +1,11 @@
 {
   "panel__settings__quick_menus__default_folder": {
     "message": "默认文件夹"
+  },
+  "panel__settings__quick_menus__enabled_title": {
+    "message": "Quick menu interception"
+  },
+  "panel__settings__quick_menus__enabled_subheader": {
+    "message": "Enable/disable the quick menu interception feature."
   }
 }

--- a/src/models/settings.model.ts
+++ b/src/models/settings.model.ts
@@ -424,6 +424,14 @@ export const defaultScrapeSettings: ScrapeSettings = {
   menu: true,
 };
 
+export interface ContentSettings {
+  intercept: boolean;
+}
+
+export const defaultContentSettings: ContentSettings = {
+  intercept: true,
+};
+
 export interface TaskSettings {
   clearOnExist: boolean;
 }
@@ -445,4 +453,5 @@ export const defaultSettings: SettingsSlice = {
   advanced: defaultAdvancedSettings,
   sync: defaultSyncSettings,
   scrape: defaultScrapeSettings,
+  content: defaultContentSettings,
 };

--- a/src/models/store.model.ts
+++ b/src/models/store.model.ts
@@ -10,6 +10,7 @@ import type { ContextMenu, QuickMenu } from './menu.model';
 import type {
   AdvancedSettings,
   ConnectionSettings,
+  ContentSettings,
   DownloadSettings,
   GlobalSettings,
   Log,
@@ -91,6 +92,7 @@ export interface SettingsSlice {
   advanced: AdvancedSettings;
   sync: SyncSettings;
   scrape: ScrapeSettings;
+  content: ContentSettings;
 }
 
 export interface RootSlice {

--- a/src/store/actions/settings.action.ts
+++ b/src/store/actions/settings.action.ts
@@ -29,6 +29,7 @@ const {
   setSyncSettings,
   syncTasksSettings,
   syncScrapeSettings,
+  syncContentSettings,
 } = settingsSlice.actions;
 
 // Export as named constants
@@ -60,4 +61,5 @@ export {
   setSyncSettings,
   syncTasksSettings,
   syncScrapeSettings,
+  syncContentSettings,
 };

--- a/src/store/selectors/settings.selector.ts
+++ b/src/store/selectors/settings.selector.ts
@@ -18,6 +18,7 @@ import {
   ConnectionType,
   defaultAdvancedSettings,
   defaultConnection,
+  defaultContentSettings,
   defaultDownloads,
   defaultGlobal,
   defaultLoggingLevels,
@@ -110,6 +111,8 @@ export const getNotificationsBannerFailedEnabled = createSelector(getNotificatio
 export const getNotificationsBannerFinishedEnabled = createSelector(getNotificationsBanner, (banner: NotificationsBanner) => banner?.scope.finished);
 
 export const getScrapeSettings = createSelector(getSettings, (setting: SettingsSlice) => setting?.scrape ?? defaultScrapeSettings);
+
+export const getContentSettings = createSelector(getSettings, (setting: SettingsSlice) => setting?.content ?? defaultContentSettings);
 
 export const getGlobal = createSelector(getSettings, (setting: SettingsSlice) => setting?.global);
 

--- a/src/store/slices/settings.slice.ts
+++ b/src/store/slices/settings.slice.ts
@@ -4,6 +4,7 @@ import type {
   AdvancedLogging,
   AdvancedSettings,
   ConnectionSettings,
+  ContentSettings,
   ContentTab,
   ContextMenu,
   DownloadSettings,
@@ -62,6 +63,7 @@ interface SettingsReducers<S = SettingsSlice> extends SliceCaseReducers<S> {
   setSyncSettings: CaseReducer<S, PayloadAction<Partial<SyncSettings>>>;
   syncTasksSettings: CaseReducer<S, PayloadAction<TaskSettings>>;
   syncScrapeSettings: CaseReducer<S, PayloadAction<Partial<ScrapeSettings>>>;
+  syncContentSettings: CaseReducer<S, PayloadAction<Partial<ContentSettings>>>;
 }
 
 export const settingsSlice = createSlice<SettingsSlice, SettingsReducers, 'settings'>({
@@ -123,5 +125,6 @@ export const settingsSlice = createSlice<SettingsSlice, SettingsReducers, 'setti
     setSyncSettings: setSyncSettingsReducer,
     syncTasksSettings: (oldSettings, { payload }) => syncNestedReducer<TaskSettings>(oldSettings, payload, 'tasks'),
     syncScrapeSettings: (oldSettings, { payload }) => syncNestedReducer<ScrapeSettings>(oldSettings, payload, 'scrape'),
+    syncContentSettings: (oldSettings, { payload }) => syncNestedReducer<ContentSettings>(oldSettings, payload, 'content'),
   },
 });

--- a/src/store/store-proxy.ts
+++ b/src/store/store-proxy.ts
@@ -1,7 +1,7 @@
 import { Store as StoreProxy } from 'webext-redux';
 
-import { StorePortName } from '@src/models';
+import { type RootSlice, StorePortName } from '@src/models';
 
-export const storeProxy = new StoreProxy({
+export const storeProxy = new StoreProxy<RootSlice>({
   portName: StorePortName,
 });


### PR DESCRIPTION
This pull request introduces a new feature to enable or disable quick menu interception, along with related updates to the codebase. 

Key changes include adding a `ContentSettings` interface, integrating the interception toggle in the UI, and updating the store and selectors to support this feature.