### PR TITLE
fix(explorer): fix filter crash

### DIFF
--- a/src/components/common/errors/error-boundary.spec.tsx
+++ b/src/components/common/errors/error-boundary.spec.tsx
@@ -1,0 +1,60 @@
+import type { FC } from 'react';
+
+import { screen } from '@testing-library/react';
+import * as React from 'react';
+import { vi } from 'vitest';
+
+import { LoggerService } from '../../../services/logger/logger.service';
+import { renderWithProviders } from '../../../test/render-helper';
+import { ErrorBoundary } from './error-boundary';
+
+// Mock the logger to avoid console spam during expected test errors
+vi.spyOn(LoggerService, 'error').mockImplementation(() => {});
+
+const ChildComponent = () => <div>Everything is fine</div>;
+const testError = new Error('Test error rendering');
+const ThrowingComponent: FC = () => {
+  throw testError;
+};
+
+describe('test ErrorBoundary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders children without error', () => {
+    const { container } = renderWithProviders(
+      <ErrorBoundary>
+        <ChildComponent />
+      </ErrorBoundary>,
+    );
+    expect(container).toBeTruthy();
+    expect(screen.getByText('Everything is fine')).toBeTruthy();
+  });
+
+  it('catches error and displays fallback UI', () => {
+    // Suppress console.error solely for React's default error logging in the test
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    renderWithProviders(
+      <ErrorBoundary name="TestComp">
+        <ThrowingComponent />
+      </ErrorBoundary>,
+    );
+
+    // Verify fallback UI
+    expect(screen.getByText('Error in TestComp')).toBeTruthy();
+    expect(screen.getByText(/Test error rendering/)).toBeTruthy();
+
+    // Verify logger was called
+    expect(LoggerService.error).toHaveBeenCalled();
+    expect(LoggerService.error).toHaveBeenCalledWith(
+      'Error caught in TestComp',
+      expect.objectContaining({
+        error: testError,
+      }),
+    );
+
+    consoleError.mockRestore();
+  });
+});

--- a/src/components/common/errors/error-boundary.tsx
+++ b/src/components/common/errors/error-boundary.tsx
@@ -1,0 +1,72 @@
+import type { ErrorInfo, ReactNode } from 'react';
+
+import { Box, Stack, Typography } from '@mui/material';
+import { Component } from 'react';
+
+import { LoggerService } from '../../../services/logger/logger.service';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  name?: string;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error?: Error;
+}
+
+class ErrorBoundaryComponent extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    const errorData = {
+      error,
+      componentStack: errorInfo.componentStack,
+    };
+    LoggerService.error(`Error caught${this.props.name ? ` in ${this.props.name}` : ''}`, errorData);
+  }
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      return (
+        <Box sx={{ p: 2, height: '100%', overflow: 'auto', bgcolor: '#fff3cd' }}>
+          <Stack spacing={1}>
+            <Typography variant="subtitle1" sx={{ fontWeight: 'bold', color: '#856404' }}>
+              {this.props.name ? `Error in ${this.props.name}` : 'Error'}
+            </Typography>
+            <Box
+              component="pre"
+              sx={{
+                p: 1.5,
+                bgcolor: '#fff',
+                border: '1px solid #ffc107',
+                borderRadius: 1,
+                fontSize: '0.75rem',
+                overflow: 'auto',
+                maxHeight: '100%',
+                fontFamily: 'monospace',
+                whiteSpace: 'pre-wrap',
+                wordBreak: 'break-word',
+                color: '#d32f2f',
+              }}
+            >
+              {this.state.error?.message}
+              {this.state.error?.stack}
+            </Box>
+          </Stack>
+        </Box>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export { ErrorBoundaryComponent as ErrorBoundary };

--- a/src/components/common/explorer/folder/explorer-leaf.tsx
+++ b/src/components/common/explorer/folder/explorer-leaf.tsx
@@ -1,5 +1,6 @@
 import type { File } from '../../../../models/file.model';
 import type { Folder } from '../../../../models/folder.model';
+import type { Tree, VisibleTree } from './explorer.utils';
 
 import FolderIcon from '@mui/icons-material/Folder';
 import InsertDriveFileOutlinedIcon from '@mui/icons-material/InsertDriveFileOutlined';
@@ -12,6 +13,7 @@ export function ExplorerLeaf({
   nodeId,
   folder,
   tree,
+  visibleTree,
   loading,
   flatten,
   disabled,
@@ -20,7 +22,8 @@ export function ExplorerLeaf({
 }: {
   nodeId: string;
   folder: Folder | File;
-  tree: Record<string, Folder[] | File[]>;
+  tree: Tree;
+  visibleTree?: VisibleTree;
   loading: Record<string, boolean>;
   flatten?: boolean;
   disabled?: boolean;
@@ -29,6 +32,7 @@ export function ExplorerLeaf({
 }) {
   const isLoading = loading[nodeId];
   const children = tree[nodeId];
+  const visibleChildren = visibleTree?.[nodeId] ?? children?.map((item, sourceIndex) => ({ item, sourceIndex }));
   return (
     <TreeItem
       itemId={`${nodeId}`}
@@ -59,12 +63,13 @@ export function ExplorerLeaf({
       {!flatten
         && folder?.isdir
         && !isLoading
-        && children?.map((sf, i) => (
+        && visibleChildren?.map(({ item: sf, sourceIndex }) => (
           <ExplorerLeaf
-            key={`${nodeId}-${i}-${disabled}`} // eslint-disable-line react/no-array-index-key -- cannot ensure name unicity
-            nodeId={`${nodeId}-${i}`}
+            key={`${nodeId}-${sourceIndex}-${disabled}`}
+            nodeId={`${nodeId}-${sourceIndex}`}
             folder={sf}
             tree={tree}
+            visibleTree={visibleTree}
             loading={loading}
             disabled={disabled}
             flatten={flatten}

--- a/src/components/common/explorer/folder/explorer.tsx
+++ b/src/components/common/explorer/folder/explorer.tsx
@@ -20,6 +20,7 @@ import { QueryService } from '../../../../services/query/query.service';
 import { getDestinationsHistory } from '../../../../store/selectors/state.selector';
 import { useDebounce } from '../../../../utils/debounce.utils';
 import { useI18n } from '../../../../utils/webex.utils';
+import { ErrorBoundary } from '../../errors/error-boundary';
 import { SearchInput } from '../../inputs/search-input';
 import { ExplorerBreadCrumbs } from './explorer-breadcrumb';
 import { ExplorerLeaf } from './explorer-leaf';
@@ -265,96 +266,98 @@ export const Explorer: FC<ExplorerProps> = ({ collapseOnSelect, flatten, disable
   }, [startPath]);
 
   return (
-    <Container ref={containerRef} disableGutters maxWidth={false} sx={{ height: '100%', outline: 'none' }} tabIndex={0}>
-      <ExplorerBreadCrumbs
-        crumbs={crumbs}
-        showDestinations={showDestinations}
-        hasDestinations={!!recentDestinations?.length}
-        onClick={async (_, i) => crumbSelect(i)}
-        onRecent={() => setShowDestinations(_show => !_show)}
-        disabled={disabled || pathLoading}
-      />
-      {showDestinations
-        ? (
-            <ExplorerRecent
-              selected={selectedPath}
-              destinations={recentDestinations}
-              onSelect={async (_path) => {
-                setShowDestinations(_show => !_show);
-                return loadNestedPath(_path);
-              }}
-            />
-          )
-        : (
-            <SimpleTreeView
-              key={`tree-${disabled}`}
-              aria-label="file system navigator"
-              slots={{ collapseIcon: FolderOpenIcon, expandIcon: FolderIcon }}
-              selectedItems={selected}
-              onSelectedItemsChange={onSelect}
-              expandedItems={expanded}
-              onExpandedItemsChange={onExpand}
-              disableSelection={disabled || pathLoading}
-              sx={{
-                overflow: 'auto',
-                transition: 'height 0.2s ease-in-out',
-                height: `calc(100% - ${filterVisible ? 4.4 : 2.0625}em)`,
-              }}
-            >
-              {
-                // only > 1 so that we do not allow creation of shares
-                flatten && editable && !pathLoading && !loading[selected] && selected?.split('-')?.length > 1 && !!selectedPath && (
-                  <ExplorerLeafAdd nodeId={selected} path={selectedPath} disabled={disabled} spliceTree={spliceTree} />
-                )
-              }
-              {flatten && <ExplorerLoading loading={pathLoading || loading[selected]} empty={!visibleTree[selected]?.length} disabled={disabled} flatten={flatten} />}
-              {flatten
-                && !pathLoading
-                && !loading[selected]
-                && visibleTree[selected]?.map(({ item, sourceIndex }) => (
-                  <ExplorerLeaf
-                    key={`${selected}-${sourceIndex}-${disabled}`}
-                    nodeId={`${selected}-${sourceIndex}`}
-                    folder={item}
-                    tree={tree}
-                    visibleTree={visibleTree}
-                    loading={loading}
-                    disabled={disabled}
-                    editable={editable}
-                    flatten={flatten}
-                    spliceTree={spliceTree}
-                  />
-                ))}
-              {!flatten
-                && !pathLoading
-                && visibleTree?.root?.map(({ item, sourceIndex }) => (
-                  <ExplorerLeaf
-                    key={`root-${sourceIndex}-${disabled}`}
-                    nodeId={`root-${sourceIndex}`}
-                    folder={item}
-                    tree={tree}
-                    visibleTree={visibleTree}
-                    loading={loading}
-                    disabled={disabled}
-                    editable={editable}
-                    flatten={flatten}
-                    spliceTree={spliceTree}
-                  />
-                ))}
-            </SimpleTreeView>
-          )}
-      <SearchInput
-        containerRef={containerRef}
-        filter={filter}
-        showFilter={search}
-        disabled={disabled}
-        onChangeFilter={setFilter}
-        onChangeVisible={setFilterVisible}
-        sx={{
-          transition: 'max-height 0.2s ease-in-out',
-          maxHeight: filterVisible ? '5rem' : 0,
-        }}
-      />
-    </Container>
+    <ErrorBoundary>
+      <Container ref={containerRef} disableGutters maxWidth={false} sx={{ height: '100%', outline: 'none' }} tabIndex={0}>
+        <ExplorerBreadCrumbs
+          crumbs={crumbs}
+          showDestinations={showDestinations}
+          hasDestinations={!!recentDestinations?.length}
+          onClick={async (_, i) => crumbSelect(i)}
+          onRecent={() => setShowDestinations(_show => !_show)}
+          disabled={disabled || pathLoading}
+        />
+        {showDestinations
+          ? (
+              <ExplorerRecent
+                selected={selectedPath}
+                destinations={recentDestinations}
+                onSelect={async (_path) => {
+                  setShowDestinations(_show => !_show);
+                  return loadNestedPath(_path);
+                }}
+              />
+            )
+          : (
+              <SimpleTreeView
+                key={`tree-${disabled}`}
+                aria-label="file system navigator"
+                slots={{ collapseIcon: FolderOpenIcon, expandIcon: FolderIcon }}
+                selectedItems={selected}
+                onSelectedItemsChange={onSelect}
+                expandedItems={expanded}
+                onExpandedItemsChange={onExpand}
+                disableSelection={disabled || pathLoading}
+                sx={{
+                  overflow: 'auto',
+                  transition: 'height 0.2s ease-in-out',
+                  height: `calc(100% - ${filterVisible ? 4.4 : 2.0625}em)`,
+                }}
+              >
+                {
+                  // only > 1 so that we do not allow creation of shares
+                  flatten && editable && !pathLoading && !loading[selected] && selected?.split('-')?.length > 1 && !!selectedPath && (
+                    <ExplorerLeafAdd nodeId={selected} path={selectedPath} disabled={disabled} spliceTree={spliceTree} />
+                  )
+                }
+                {flatten && <ExplorerLoading loading={pathLoading || loading[selected]} empty={!visibleTree[selected]?.length} disabled={disabled} flatten={flatten} />}
+                {flatten
+                  && !pathLoading
+                  && !loading[selected]
+                  && visibleTree[selected]?.map(({ item, sourceIndex }) => (
+                    <ExplorerLeaf
+                      key={`${selected}-${sourceIndex}-${disabled}`}
+                      nodeId={`${selected}-${sourceIndex}`}
+                      folder={item}
+                      tree={tree}
+                      visibleTree={visibleTree}
+                      loading={loading}
+                      disabled={disabled}
+                      editable={editable}
+                      flatten={flatten}
+                      spliceTree={spliceTree}
+                    />
+                  ))}
+                {!flatten
+                  && !pathLoading
+                  && visibleTree?.root?.map(({ item, sourceIndex }) => (
+                    <ExplorerLeaf
+                      key={`root-${sourceIndex}-${disabled}`}
+                      nodeId={`root-${sourceIndex}`}
+                      folder={item}
+                      tree={tree}
+                      visibleTree={visibleTree}
+                      loading={loading}
+                      disabled={disabled}
+                      editable={editable}
+                      flatten={flatten}
+                      spliceTree={spliceTree}
+                    />
+                  ))}
+              </SimpleTreeView>
+            )}
+        <SearchInput
+          containerRef={containerRef}
+          filter={filter}
+          showFilter={search}
+          disabled={disabled}
+          onChangeFilter={setFilter}
+          onChangeVisible={setFilterVisible}
+          sx={{
+            transition: 'max-height 0.2s ease-in-out',
+            maxHeight: filterVisible ? '5rem' : 0,
+          }}
+        />
+      </Container>
+    </ErrorBoundary>
   );
 };

--- a/src/components/common/explorer/folder/explorer.tsx
+++ b/src/components/common/explorer/folder/explorer.tsx
@@ -4,6 +4,7 @@ import type { Observable } from 'rxjs';
 import type { File, FileList } from '../../../../models/file.model';
 import type { Folder } from '../../../../models/folder.model';
 import type { RootSlice } from '../../../../models/store.model';
+import type { Tree } from './explorer.utils';
 
 import FolderIcon from '@mui/icons-material/Folder';
 import FolderOpenIcon from '@mui/icons-material/FolderOpen';
@@ -25,6 +26,7 @@ import { ExplorerLeaf } from './explorer-leaf';
 import { ExplorerLeafAdd } from './explorer-leaf-add';
 import { ExplorerLoading } from './explorer-loading';
 import { ExplorerRecent } from './explorer-recent';
+import { buildVisibleTree } from './explorer.utils';
 
 export interface ExplorerProps {
   collapseOnSelect?: boolean;
@@ -43,8 +45,6 @@ export interface ExplorerEvent {
   path?: string;
   folder?: File | Folder;
 }
-
-type Tree = Record<string, (Folder | File)[]>;
 
 // TODO implement virtual scroll
 export const Explorer: FC<ExplorerProps> = ({ collapseOnSelect, flatten, disabled, readonly, fileType, startPath, onChange, editable, search }) => {
@@ -69,13 +69,7 @@ export const Explorer: FC<ExplorerProps> = ({ collapseOnSelect, flatten, disable
     return disabled || !filter || f?.name?.trim()?.toLowerCase()?.includes(filter?.trim()?.toLowerCase());
   }, [disabled, filter]);
 
-  const filteredTree = useMemo(() => {
-    if (!filterVisible || !tree) return tree;
-    return Object.entries(tree).reduce((curr, [key, value]) => {
-      curr[key] = value?.filter(doFilter);
-      return curr;
-    }, {} as Tree);
-  }, [tree, filterVisible, doFilter]);
+  const visibleTree = useMemo(() => buildVisibleTree(tree, filterVisible, doFilter), [tree, filterVisible, doFilter]);
 
   const isLoginCheck = () => {
     if (QueryService.isLoggedIn) return true;
@@ -155,18 +149,19 @@ export const Explorer: FC<ExplorerProps> = ({ collapseOnSelect, flatten, disable
 
     const ids = nodeId.split('-');
     const index = Number(ids.pop());
-    const folder = filteredTree[ids?.join('-')][index];
+    const folder = tree[ids?.join('-')]?.[index];
+    if (!folder) return tree;
     const path = folder.path.split('/')?.slice(1);
 
     if (!flatten && collapseOnSelect) {
       setExpanded([...expanded.filter(id => nodeId.startsWith(id)), nodeId]);
     }
 
-    if (!filteredTree[nodeId] && flatten) {
+    if (!tree[nodeId] && flatten) {
       onSelectChange(nodeId, path);
       return lastValueFrom(loadFilesIntoTree(folder.path, nodeId));
     }
-    if (!filteredTree[nodeId]) {
+    if (!tree[nodeId]) {
       const _tree = await lastValueFrom(loadFilesIntoTree(folder.path, nodeId));
       onSelectChange(nodeId, path, folder);
       return _tree;
@@ -203,7 +198,7 @@ export const Explorer: FC<ExplorerProps> = ({ collapseOnSelect, flatten, disable
           const nodePath = nodeId.split('-');
           const index = Number(nodePath?.pop());
 
-          if (index && Number.isInteger(index)) {
+          if (Number.isInteger(index) && index >= 0) {
             _new[nodePath.join('-')][index] = newFolder;
           }
         }
@@ -216,7 +211,7 @@ export const Explorer: FC<ExplorerProps> = ({ collapseOnSelect, flatten, disable
     // if old folder exit
     if (oldFolder?.name) return;
     // else select new folder
-    return selectNode(`${nodeId}-${(filteredTree[nodeId]?.length ?? 1) - 1}`);
+    return selectNode(`${nodeId}-${(tree[nodeId]?.length ?? 1) - 1}`);
   };
 
   const onSelect = async ($event: SyntheticEvent | null, itemId: string | null) => itemId && selectNode(itemId);
@@ -312,16 +307,17 @@ export const Explorer: FC<ExplorerProps> = ({ collapseOnSelect, flatten, disable
                   <ExplorerLeafAdd nodeId={selected} path={selectedPath} disabled={disabled} spliceTree={spliceTree} />
                 )
               }
-              {flatten && <ExplorerLoading loading={pathLoading || loading[selected]} empty={!filteredTree[selected]?.length} disabled={disabled} flatten={flatten} />}
+              {flatten && <ExplorerLoading loading={pathLoading || loading[selected]} empty={!visibleTree[selected]?.length} disabled={disabled} flatten={flatten} />}
               {flatten
                 && !pathLoading
                 && !loading[selected]
-                && filteredTree[selected]?.map((f, i) => (
+                && visibleTree[selected]?.map(({ item, sourceIndex }) => (
                   <ExplorerLeaf
-                    key={`${f.name}-${disabled}`}
-                    nodeId={`${selected}-${i}`}
-                    folder={f}
-                    tree={filteredTree}
+                    key={`${selected}-${sourceIndex}-${disabled}`}
+                    nodeId={`${selected}-${sourceIndex}`}
+                    folder={item}
+                    tree={tree}
+                    visibleTree={visibleTree}
                     loading={loading}
                     disabled={disabled}
                     editable={editable}
@@ -331,12 +327,13 @@ export const Explorer: FC<ExplorerProps> = ({ collapseOnSelect, flatten, disable
                 ))}
               {!flatten
                 && !pathLoading
-                && filteredTree?.root?.map((f, i) => (
+                && visibleTree?.root?.map(({ item, sourceIndex }) => (
                   <ExplorerLeaf
-                    key={`${f.name}-${disabled}`}
-                    nodeId={`root-${i}`}
-                    folder={f}
-                    tree={filteredTree}
+                    key={`root-${sourceIndex}-${disabled}`}
+                    nodeId={`root-${sourceIndex}`}
+                    folder={item}
+                    tree={tree}
+                    visibleTree={visibleTree}
                     loading={loading}
                     disabled={disabled}
                     editable={editable}

--- a/src/components/common/explorer/folder/explorer.utils.spec.ts
+++ b/src/components/common/explorer/folder/explorer.utils.spec.ts
@@ -1,0 +1,46 @@
+import type { File } from '../../../../models/file.model';
+import type { Tree } from './explorer.utils';
+
+import { buildVisibleTree } from './explorer.utils';
+
+function makeNode(name: string): File {
+  return {
+    isdir: true,
+    name,
+    path: `/${name}`,
+  };
+}
+
+describe('explorer.utils', () => {
+  it('keeps original source indices for sparse root filtering', () => {
+    const tree: Tree = {
+      root: [makeNode('alpha'), makeNode('beta'), makeNode('gamma'), makeNode('delta')],
+    };
+
+    const visibleTree = buildVisibleTree(tree, true, node => ['alpha', 'delta'].includes(node.name));
+
+    expect(visibleTree.root.map(({ sourceIndex }) => sourceIndex)).toEqual([0, 3]);
+  });
+
+  it('keeps original source indices for nested filtering', () => {
+    const tree: Tree = {
+      'root': [makeNode('parent')],
+      'root-0': [makeNode('child-0'), makeNode('child-1'), makeNode('child-2')],
+    };
+
+    const visibleTree = buildVisibleTree(tree, true, node => node.name !== 'child-1');
+
+    expect(visibleTree['root-0'].map(({ sourceIndex }) => sourceIndex)).toEqual([0, 2]);
+    expect(visibleTree['root-0'].map(({ sourceIndex }) => `root-0-${sourceIndex}`)).toEqual(['root-0-0', 'root-0-2']);
+  });
+
+  it('returns all nodes when filter is not visible', () => {
+    const tree: Tree = {
+      root: [makeNode('alpha'), makeNode('beta')],
+    };
+
+    const visibleTree = buildVisibleTree(tree, false, () => false);
+
+    expect(visibleTree.root.map(({ sourceIndex }) => sourceIndex)).toEqual([0, 1]);
+  });
+});

--- a/src/components/common/explorer/folder/explorer.utils.ts
+++ b/src/components/common/explorer/folder/explorer.utils.ts
@@ -1,0 +1,20 @@
+import type { File } from '../../../../models/file.model';
+import type { Folder } from '../../../../models/folder.model';
+
+export type TreeNode = Folder | File;
+export type Tree = Record<string, TreeNode[]>;
+
+export interface VisibleTreeEntry {
+  item: TreeNode;
+  sourceIndex: number;
+}
+
+export type VisibleTree = Record<string, VisibleTreeEntry[]>;
+
+export function buildVisibleTree(tree: Tree, filterVisible: boolean, predicate: (node: TreeNode) => boolean): VisibleTree {
+  return Object.entries(tree ?? {}).reduce((acc, [key, nodes]) => {
+    const indexed = (nodes ?? []).map((item, sourceIndex) => ({ item, sourceIndex }));
+    acc[key] = filterVisible ? indexed.filter(({ item }) => predicate(item)) : indexed;
+    return acc;
+  }, {} as VisibleTree);
+}


### PR DESCRIPTION
This pull request introduces an error boundary component and refactors the file/folder explorer to improve filtering and error handling. It adds robust error boundaries, enhances the explorer's filtering logic to preserve original indices, and introduces comprehensive tests and utilities for these changes.

**Error handling improvements:**

* Added a reusable `ErrorBoundary` component (`error-boundary.tsx`) that catches and logs errors in child components, displaying a user-friendly fallback UI. Includes corresponding unit tests to verify error catching and logging (`error-boundary.spec.tsx`). [[1]](diffhunk://#diff-c7c1a7681c3684707494cf4b7d920fa3a0ce0d96978df49a5e6984f67c5f3fb2R1-R72) [[2]](diffhunk://#diff-669c768ed0fd30905b4b55f5844c1b75f38bf075eb467e1bf9047bc988a73b5dR1-R60)
* Wrapped the main Explorer component in the new `ErrorBoundary` to prevent unhandled errors from breaking the UI (`explorer.tsx`). (F740ad8fL266, F740ad8fL358)

**Explorer filtering and tree logic:**

* Refactored the explorer to use a new `buildVisibleTree` utility, which generates a filtered tree structure while preserving the original source indices for each node. This ensures correct mapping between filtered and unfiltered data, especially for nested folders (`explorer.tsx`, `explorer-leaf.tsx`, `explorer.utils.ts`). (F740ad8fL70, F99aa178L32, [src/components/common/explorer/folder/explorer.utils.tsR1-R20](diffhunk://#diff-a64fb0b7f9be0bb454fcb7efef21dae7cd3348a989f150e9156b1974a8a02780R1-R20))
* Updated the explorer's rendering logic to use the new `visibleTree` structure, ensuring correct keying and node selection after filtering. (F99aa178L63, F740ad8fL309, F740ad8fL329)

**Testing and utilities:**

* Added comprehensive unit tests for the `buildVisibleTree` utility to verify correct index preservation and filtering behavior (`explorer.utils.spec.ts`).
* Defined and exported new types (`Tree`, `VisibleTree`, etc.) to clarify tree data structures and improve type safety (`explorer.utils.ts`).